### PR TITLE
Update refs for migrated repos

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "polymer": "Polymer/polymer#^1.2.0",
     "fs-alert": "fs-webdev/fs-alert#0.2.0",
-    "fs-standards-picker": "fs-webdev/fs-standards-picker#2.x",
+    "birch-standards-picker": "FamilySearchElements/birch-standards-picker#2.x",
     "wc-i18n": "jshcrowthe/wc-i18n#2.x",
     "oak-i18n-behavior": "FamilySearchElements/oak-i18n-behavior#1.x",
     "fs-styles": "fs-webdev/fs-styles#2.x",

--- a/bower.json
+++ b/bower.json
@@ -19,8 +19,8 @@
   ],
   "dependencies": {
     "polymer": "Polymer/polymer#^1.2.0",
-    "cedar-alert": "FamilySearchElements/cedar-alert#0.2.0",
-    "birch-standards-picker": "FamilySearchElements/birch-standards-picker#2.x",
+    "fs-alert": "fs-webdev/fs-alert#0.2.0",
+    "fs-standards-picker": "fs-webdev/fs-standards-picker#2.x",
     "wc-i18n": "jshcrowthe/wc-i18n#2.x",
     "oak-i18n-behavior": "FamilySearchElements/oak-i18n-behavior#1.x",
     "fs-styles": "fs-webdev/fs-styles#2.x",

--- a/fs-memories-standards-picker.css
+++ b/fs-memories-standards-picker.css
@@ -5,7 +5,7 @@
   font-size: 12px;
   max-width: 300px;
 }
-fs-standards-picker {
+birch-standards-picker {
   margin-bottom: 10px;
   padding: 5px 3.5px;
   padding: 0.35rem 0.25rem;

--- a/fs-memories-standards-picker.css
+++ b/fs-memories-standards-picker.css
@@ -5,7 +5,7 @@
   font-size: 12px;
   max-width: 300px;
 }
-birch-standards-picker {
+fs-standards-picker {
   margin-bottom: 10px;
   padding: 5px 3.5px;
   padding: 0.35rem 0.25rem;

--- a/fs-memories-standards-picker.html
+++ b/fs-memories-standards-picker.html
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../fs-alert/fs-alert.html">
 <link rel="import" href="../cedar-dialog/cedar-dialog.html">
-<link rel="import" href="../fs-standards-picker/fs-standards-picker.html">
+<link rel="import" href="../birch-standards-picker/birch-standards-picker.html">
 <link rel="import" href="../wc-i18n/wc-i18n.html">
 <link rel="import" href="../fs-styles/fs-styles.html">
 <link rel="import" href="../fs-metrics/fs-metrics.html">
@@ -114,13 +114,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
 
     <template is="dom-if" if="[[_same(mode, 'edit')]]">
-      <fs-standards-picker id="picker"
+      <birch-standards-picker id="picker"
         data="[[_data]]"
         search-term="[[_getText(_data)]]"
         standard-type="[[standardType]]"
         on-birch-typeahead:input="_handleInput"
         on-birch-typeahead:selected="_handleSelection">
-      </fs-standards-picker/>
+      </birch-standards-picker/>
 
       <div class="save-cancel-buttons vertical-center">
         <button id="save-button"
@@ -198,8 +198,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       listeners: {
-        'fs-standards-picker:update-data': '_handleDataChange',
-        'fs-standards-picker:error': '_handleError'
+        'birch-standards-picker:update-data': '_handleDataChange',
+        'birch-standards-picker:error': '_handleError'
       },
 
       ready: function() {

--- a/fs-memories-standards-picker.html
+++ b/fs-memories-standards-picker.html
@@ -9,9 +9,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../cedar-alert/cedar-alert.html">
+<link rel="import" href="../fs-alert/fs-alert.html">
 <link rel="import" href="../cedar-dialog/cedar-dialog.html">
-<link rel="import" href="../birch-standards-picker/birch-standards-picker.html">
+<link rel="import" href="../fs-standards-picker/fs-standards-picker.html">
 <link rel="import" href="../wc-i18n/wc-i18n.html">
 <link rel="import" href="../fs-styles/fs-styles.html">
 <link rel="import" href="../fs-metrics/fs-metrics.html">
@@ -51,9 +51,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </div>
     </cedar-dialog>
 
-    <cedar-alert id="alert" alert-type="error" hidden>
+    <fs-alert id="alert" alert-type="error" hidden>
       [[i18n('error')]]
-    </cedar-alert>
+    </fs-alert>
 
     <template is="dom-if" if="[[_same(mode, 'view')]]">
       <div id="view">
@@ -114,13 +114,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
 
     <template is="dom-if" if="[[_same(mode, 'edit')]]">
-      <birch-standards-picker id="picker"
+      <fs-standards-picker id="picker"
         data="[[_data]]"
         search-term="[[_getText(_data)]]"
         standard-type="[[standardType]]"
         on-birch-typeahead:input="_handleInput"
         on-birch-typeahead:selected="_handleSelection">
-      </birch-standards-picker/>
+      </fs-standards-picker/>
 
       <div class="save-cancel-buttons vertical-center">
         <button id="save-button"
@@ -198,8 +198,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       listeners: {
-        'birch-standards-picker:update-data': '_handleDataChange',
-        'birch-standards-picker:error': '_handleError'
+        'fs-standards-picker:update-data': '_handleDataChange',
+        'fs-standards-picker:error': '_handleError'
       },
 
       ready: function() {


### PR DESCRIPTION
This update applies to any dependencies, imports, or implementations of the repos migrated from the `FamilySearchElements` to `Fs-WebDev` org.