### PR TITLE
PS-3455:  Reset the input value after saving

### DIFF
--- a/fs-memories-standards-picker.html
+++ b/fs-memories-standards-picker.html
@@ -501,7 +501,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var picker = this.$$('#picker');
         if(picker){
           this._data = picker.data;
-          this._data.label = picker.data.label
+          this._data.label = picker.data.label;
+          picker.reset();
         }
         this._disableSaveButton = true;
         this.mode = 'view';


### PR DESCRIPTION
## Problem
If the input value is not reset, it bleeds into the next artifact when using Next/Previous and then trying to add a date or place.

### Changes
- Reset the input value after a successful save.

NOTE:  This has been tested and approved by Jeff Porter.
