### PR TITLE
PS-3454:  Reset to 'view' mode when changing artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: node_js
-sudo: false
+sudo: true
 dist: trusty
-before_script:
+before_install:
   - echo -e "machine github.com\n  login $CI_USER_TOKEN" >> ~/.netrc
+before_script:
   - npm install -g bower web-component-tester
   - bower install
 env:
   global:
-    - secure: gZ5vpMlc9fuKSZeMmT6xf4+FIVWxET6f6Lkp6l5Qo9vL2X/KC/bMJF1v2w5xXFLFTdm/hPUDkeQRDUBBJhGcsXhJeWIvAXdPkObV9ZPRwpDnnN1qU5lOqVIy6gFjDm2Wm6UNXcRnyP1TrGpMwbG13EUtD0rF8LZqBm3B833sKS4=
-    - secure: DObDewETPYiIsASeC3UETPbQ6YBniRZdNV2eTM1xULvuFNDxXJD09KKyWOiMduublEIJRXLjBIXmD8cbVsgrbRUYA4bxcXffDeuc6q6HaQGU9HvIbLz6o3/oxi4fX2G9GwrZtijW2p2Rgw2l9koR3ovjcM97CSTWFUMh5rtXag8=
     - CXX=g++-4.8
-node_js: stable
+node_js: "8"
 cache:
   directories:
   - bower_components
@@ -25,5 +24,6 @@ addons:
       - g++-4.8
   sauce_connect: true
 script:
-  - xvfb-run wct
-  - "if [ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ]; then wct --plugin sauce; fi"
+  - xvfb-run wct test/
+  - "if [ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ]; then wct test/ --plugin sauce; fi"
+

--- a/fs-memories-standards-picker.html
+++ b/fs-memories-standards-picker.html
@@ -206,7 +206,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         data="[[_data]]"
         standard-type="[[standardType]]"
         on-birch-typeahead:selected="_handleSelection">
-      </birch-standards-picker/>
+      </birch-standards-picker>
 
       <div class="save-cancel-buttons vertical-center">
         <button id="save-button"
@@ -354,6 +354,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _handleArtifactChange: function(artifact) {
         if(!artifact) return;
+
+        this.mode = 'view';
+
+        var picker = this.$$('#picker');
+        if (picker) {
+          picker.reset();
+        }
+
         var dp;
         if(artifact.datesPlaces && artifact.datesPlaces[0]){
           dp = artifact.datesPlaces[0];
@@ -367,7 +375,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             customText: dp[this.standardType + 'NonStandardizedText'],
             label: dp.label
           };
-          var picker = this.$$('#picker');
+
           if(picker){
             this._data.label = picker.data.label;
           }

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -13,12 +13,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
-    <script>
-      // FS = FS || {};
-      // FS.i18n = function(key) {return key;}
-    </script>
-
-
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
     <script src="../../sinonjs/sinon.js"></script>

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -13,6 +13,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
+    <script>
+      // FS = FS || {};
+      // FS.i18n = function(key) {return key;}
+    </script>
+
+
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
     <script src="../../sinonjs/sinon.js"></script>
@@ -37,6 +43,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         trackLink: function() {},
         trackData: function() {}
       };
+
+      FS.i18n = function(key) {return key;}
+
       suite('<fs-memories-standards-picker>', function() {
 
         var el;
@@ -142,12 +151,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(el._hasText({customText: '', standardText: ''})).to.be.false;
         });
 
-        test('_getText', function() {
-          expect(el._getText({customText: 'a', standardText: 'b'})).to.equal('a');
-          expect(el._getText({customText: 'a', standardText: ''})).to.equal('a');
-          expect(el._getText({customText: '', standardText: 'b'})).to.equal('b');
-        });
-
         test('_handleSelection', function() {
           el._disableSaveButton = true;
 
@@ -156,12 +159,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           el._handleSelection({detail: {selection: {}}});
           expect(el._disableSaveButton).to.be.false;
-        });
-
-        test('_handleInput', function() {
-          el._disableSaveButton = false;
-          el._handleInput();
-          expect(el._disableSaveButton).to.be.true;
         });
 
         // test('_handleSave', function() {
@@ -205,7 +202,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           el.$.confirmDeleteButton.disabled = true;
           el.$.confirmDeleteButton.loading = true;
 
-          el._handleError();
+          var e = {detail: {status: 200}};
+          el._handleError(e);
           expect(el.loading).to.be.false;
           expect(el.$.confirmDeleteButton.disabled).to.be.false;
           expect(el.$.confirmDeleteButton.loading).to.be.false;
@@ -226,7 +224,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('_showDeleteConfirmation', function() {
           var openConfrimDeleteSpy = sinon.spy(el.$.confirmationDialog, 'open');
-          el._showDeleteConfirmation();
+          var e = {currentTarget: {}};
+          el._showDeleteConfirmation(e);
           expect(openConfrimDeleteSpy.calledOnce).to.be.true;
           openConfrimDeleteSpy.restore();
         });

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -3,10 +3,9 @@ module.exports = {
     "sauce": {
       "disabled": true,
       "browsers": [
-        "Windows 8.1/internet explorer",
         "Windows 10/microsoftedge",
-        "OS X 10.12/safari"
+        "OS X 10.13/safari"
     ]
     }
   }
-}
+};


### PR DESCRIPTION
## Problem
If the user clicks `Next` or `Previous` while adding or editing a date or place, the next viewed artifact still has the date or place in `edit` mode.

### Changes
- Change the date and place pickers back to `view` mode when the artifact changes.