### PR TITLE
fix input for non-chrome browsers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-memories-standards-picker",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "authors": [
     "Anonymous <anonymous@example.com>"
   ],

--- a/fs-memories-standards-picker.html
+++ b/fs-memories-standards-picker.html
@@ -424,6 +424,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var picker = this.$$('#picker');
           if(picker){
             picker.$.typeahead.$.input.focus();
+            /******************************************************************************
+              In non-chrome browsers the birch-type-ahead-input mixin isn't getting applied
+              The proper way to fix this would be to stop forcing shady dom but that may
+              break other things.
+             ******************************************************************************
+              background-color: #fff;
+              border: 1px solid #ccc;
+              border-radius: 4px;
+              box-shadow: inset 0 3px 0 rgba(0,0,0,0.05);
+              box-sizing: border-box;
+              color: #333331;
+              padding: 6px 10px 6px 25px;
+            */
+            picker.$.typeahead.$.input.style.backgroundColor = "#fff";
+            picker.$.typeahead.$.input.style.border = "1px solid #ccc";
+            picker.$.typeahead.$.input.style.borderRadius = "4px";
+            picker.$.typeahead.$.input.style.boxShadow = "inset 0 3px 0 rgba(0,0,0,0.05)";
+            picker.$.typeahead.$.input.style.color = "#333331";
+            picker.$.typeahead.$.input.style.padding = "6px 10px 6px 25px";
           }
         });
       },


### PR DESCRIPTION
Nested mixins apparently don't work in shadyDOM. 

This fixes the input so it will go from **this:**

![image](https://user-images.githubusercontent.com/7363722/64039203-5149fb00-cb17-11e9-8e82-b16bf820621d.png)

**to this:**

![image](https://user-images.githubusercontent.com/7363722/64039256-7474aa80-cb17-11e9-9982-51e35d7427c5.png)

